### PR TITLE
fix(dependecy) update babel to bable-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "manifest": "d2-manifest package.json build/manifest.webapp"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
fix npm installation failure because `babel` is deprecated in favor of `babel-cli`

![capture](https://user-images.githubusercontent.com/8130692/31306339-a38555d2-ab56-11e7-8a5e-b26803b1d440.PNG)
