### PR TITLE
Fetch translations with same-origin credentials to avoid 302

### DIFF
--- a/includes/feedback-tool/feedback-dhis2.js
+++ b/includes/feedback-tool/feedback-dhis2.js
@@ -54,7 +54,8 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
                             feedbackOptions: { i18nProperties: i18nProperties }
                         }));
                     };
-                    fetch("includes/feedback-tool/i18n/" + locale + ".properties").then(function (res) {
+
+                    fetch("includes/feedback-tool/i18n/" + locale + ".properties", { credentials: 'same-origin' }).then(function (res) {
                         return res.status.toString().match(/^2..$/) ? res : throwError("Cannot find locale");
                     }).then(function (res) {
                         return res.text();


### PR DESCRIPTION
Closes #59 

When getting translations with `fetch`, we must use `credentials: 'include'` so it works on production.

Documentation:
https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Sending_a_request_with_credentials_included